### PR TITLE
fix: Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ sequenceDiagram
 
 ## Installation
 
-**Requirements:** Claude Code 2.0.22+ (uses AskUserQuestion tool for targeted clarifying questions)
+**Requirements:**
+- Claude Code 2.0.22+ (uses AskUserQuestion tool for targeted clarifying questions)
+- Python 3.10+
+
+> **Windows users:** The plugin uses the Python Launcher (`py -3`) which comes with standard Python installations. Ensure Python is installed from [python.org](https://python.org).
 
 ### Option 1: Via Marketplace (Recommended)
 
@@ -96,6 +100,8 @@ chmod +x ~/.claude/hooks/improve-prompt.py
 ```
 
 **2. Update `~/.claude/settings.json`:**
+
+On macOS/Linux:
 ```json
 {
   "hooks": {
@@ -105,6 +111,24 @@ chmod +x ~/.claude/hooks/improve-prompt.py
           {
             "type": "command",
             "command": "python3 ~/.claude/hooks/improve-prompt.py"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+On Windows:
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "py -3 -u \"~/.claude/hooks/improve-prompt.py\""
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/improve-prompt.py",
+            "command": "py -3 -u \"${CLAUDE_PLUGIN_ROOT}/scripts/improve-prompt.py\"",
+            "timeout": 10,
             "description": "Run the prompt improvement script"
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py -3 -u \"${CLAUDE_PLUGIN_ROOT}/scripts/improve-prompt.py\"",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/run-hook.sh\"",
             "timeout": 10,
             "description": "Run the prompt improvement script"
           }

--- a/scripts/improve-prompt.py
+++ b/scripts/improve-prompt.py
@@ -6,11 +6,19 @@ Evaluates prompts for clarity and invokes the prompt-improver skill for vague ca
 import json
 import sys
 
+# Handle Windows stdin encoding
+if sys.platform == "win32":
+    import io
+    sys.stdin = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
+
 # Load input from stdin
 try:
     input_data = json.load(sys.stdin)
 except json.JSONDecodeError as e:
     print(f"Error: Invalid JSON input: {e}", file=sys.stderr)
+    sys.exit(1)
+except Exception as e:
+    print(f"Error reading input: {e}", file=sys.stderr)
     sys.exit(1)
 
 prompt = input_data.get("prompt", "")
@@ -26,7 +34,7 @@ def output_json(text):
             "additionalContext": text
         }
     }
-    print(json.dumps(output))
+    print(json.dumps(output), flush=True)
 
 # Check for bypass conditions
 # 1. Explicit bypass with * prefix

--- a/scripts/run-hook.sh
+++ b/scripts/run-hook.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Cross-platform wrapper to invoke Python with the correct interpreter
+# - Linux/macOS: uses python3
+# - Windows (Git Bash/MSYS/Cygwin): uses py -3
+
+SCRIPT_DIR="$(dirname "$0")"
+HOOK_SCRIPT="$SCRIPT_DIR/improve-prompt.py"
+
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OS" == "Windows_NT" ]]; then
+    py -3 -u "$HOOK_SCRIPT"
+else
+    python3 -u "$HOOK_SCRIPT"
+fi


### PR DESCRIPTION
- Change hook command from python3 to py -3 (Python Launcher for Windows)
- Add quotes around path for paths with spaces
- Add -u flag for unbuffered output
- Add timeout of 10 seconds
- Add Windows stdin UTF-8 encoding handling
- Add flush=True to output for proper buffering
- Update README with Windows requirements and instructions

Windows doesn't have python3 command - it uses 'python' or 'py -3' (Python Launcher). The App Execution Alias for 'python' redirects to Microsoft Store, so 'py -3' is the most reliable cross-platform approach for Windows.