### PR TITLE
Release v0.5.1: Windows compatibility and CLAUDE.md refresh

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt-improver",
   "description": "Intelligent prompt optimization using skill-based architecture. Enriches vague prompts with research-based clarifying questions before Claude Code executes them",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "severity1"
   },

--- a/.claude/auto-memory/config.json
+++ b/.claude/auto-memory/config.json
@@ -1,0 +1,3 @@
+{
+  "triggerMode": "default"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,49 +1,22 @@
 # Claude Code Prompt Improver
 
+This file provides guidance to Claude Code when working with code in this repository.
+
 <!-- AUTO-MANAGED: project-description -->
-A UserPromptSubmit hook that enriches vague prompts before Claude Code executes them. Uses skill-based architecture with hook-level evaluation for efficient prompt clarity assessment.
+## Overview
+
+A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code executes them. Uses skill-based architecture with hook-level evaluation for efficient prompt clarity assessment.
 
 **Core functionality:**
 - Intercepts prompts via UserPromptSubmit hook
 - Evaluates clarity using conversation history
-- Clear prompts: proceeds immediately (189 token overhead)
+- Clear prompts: proceeds immediately with minimal overhead
 - Vague prompts: invokes prompt-improver skill for research and clarification
 - Uses AskUserQuestion tool for targeted clarifying questions (1-6 questions)
-
-**Requirements:** Claude Code 2.0.22+ (requires AskUserQuestion tool)
-<!-- END AUTO-MANAGED -->
-
-<!-- AUTO-MANAGED: architecture -->
-## Architecture
-
-**Hook Layer (scripts/improve-prompt.py):**
-- 71 lines - evaluation orchestrator
-- Intercepts via stdin/stdout JSON
-- Handles bypass prefixes: `*` (skip), `/` (slash commands), `#` (memorize)
-- Wraps prompts with evaluation instructions (189 tokens)
-- Claude evaluates clarity using conversation history
-- If vague: instructs Claude to invoke prompt-improver skill
-
-**Skill Layer (skills/prompt-improver/):**
-- `SKILL.md`: Research and question workflow (170 lines)
-  - 4-phase process: Research → Questions → Clarify → Execute
-  - Assumes prompt already determined vague by hook
-  - Links to reference files for progressive disclosure
-- `references/`: Detailed guides loaded on-demand
-  - `question-patterns.md`: Question templates (200-300 lines)
-  - `research-strategies.md`: Context gathering (300-400 lines)
-  - `examples.md`: Real transformations (200-300 lines)
-
-**Directory structure:**
-- `scripts/` - Hook implementation
-- `skills/prompt-improver/` - Skill and reference files
-- `tests/` - Test suite (hook, skill, integration)
-- `hooks/` - Hook configuration (hooks.json)
-- `.claude-plugin/` - Plugin metadata
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: build-commands -->
-## Build Commands
+## Build & Development Commands
 
 **Testing:**
 - Run all tests: `pytest tests/` or `python -m pytest`
@@ -59,16 +32,45 @@ A UserPromptSubmit hook that enriches vague prompts before Claude Code executes 
 - Manual hook: `cp scripts/improve-prompt.py ~/.claude/hooks/ && chmod +x ~/.claude/hooks/improve-prompt.py`
 <!-- END AUTO-MANAGED -->
 
+<!-- AUTO-MANAGED: architecture -->
+## Architecture
+
+**Hook Layer (scripts/improve-prompt.py):**
+- Evaluation orchestrator - reads stdin JSON, writes stdout JSON
+- Handles bypass prefixes: `*` (skip), `/` (slash commands), `#` (memorize)
+- Wraps prompts with evaluation instructions for clarity assessment
+- Claude evaluates clarity using conversation history
+- If vague: instructs Claude to invoke prompt-improver skill
+
+**Skill Layer (skills/prompt-improver/):**
+- `SKILL.md`: Research and question workflow
+  - 4-phase process: Research, Questions, Clarify, Execute
+  - Assumes prompt already determined vague by hook
+  - Links to reference files for progressive disclosure
+- `references/`: Detailed guides loaded on-demand
+  - `question-patterns.md`: Question templates and effective patterns
+  - `research-strategies.md`: Context gathering strategies
+  - `examples.md`: Real prompt transformations
+
+**Directory structure:**
+- `scripts/` - Hook implementation
+- `skills/prompt-improver/` - Skill and reference files
+- `tests/` - Test suite (hook, skill, integration)
+- `hooks/` - Hook configuration (hooks.json, auto-discovered)
+- `.claude-plugin/` - Plugin metadata
+<!-- END AUTO-MANAGED -->
+
 <!-- AUTO-MANAGED: conventions -->
-## Conventions
+## Code Conventions
 
 **Hook output format:**
 - JSON structure following Claude Code specification
 - Format: `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "..."}}`
 - Exit code 0 for all success paths
+- Hook commands use `python3 || python` fallback for Windows compatibility
 
 **Bypass prefixes:**
-- `*` prefix: Skip evaluation entirely
+- `*` prefix: Skip evaluation entirely, strip prefix from prompt
 - `/` prefix: Slash commands bypass automatically
 - `#` prefix: Memorize commands bypass automatically
 
@@ -82,13 +84,20 @@ A UserPromptSubmit hook that enriches vague prompts before Claude Code executes 
 - Description: under 1024 chars, includes activation triggers
 - Reference files: self-contained, one-level deep
 - Writing style: imperative/infinitive form (avoid "you/your")
+
+**Testing:**
+- Tests use pytest-compatible functions (no test classes)
+- Hook tests run the script via subprocess and validate JSON output
+- Skill tests validate file structure, frontmatter, and references
+- Integration tests verify end-to-end flow and architecture separation
+- Python standard library only (json, sys, subprocess, pathlib, re)
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: patterns -->
-## Patterns
+## Detected Patterns
 
 **Progressive disclosure:**
-- Clear prompts: evaluation only (189 tokens), no skill load
+- Clear prompts: evaluation only, no skill load
 - Vague prompts: evaluation + skill load + references
 - Reference materials load only when needed
 - Zero context penalty for unused reference materials
@@ -97,7 +106,7 @@ A UserPromptSubmit hook that enriches vague prompts before Claude Code executes 
 1. Hook wraps prompt with evaluation instructions
 2. Claude evaluates using conversation history
 3. If clear: proceed immediately
-4. If vague: invoke prompt-improver skill → research → questions → execute
+4. If vague: invoke prompt-improver skill, then research, questions, execute
 
 **Research and questioning:**
 - Create dynamic research plan via TodoWrite
@@ -105,6 +114,31 @@ A UserPromptSubmit hook that enriches vague prompts before Claude Code executes 
 - Ground questions in research findings (not generic assumptions)
 - Support 1-6 questions for complex scenarios
 - Use conversation history to avoid redundant exploration
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: git-insights -->
+## Git Insights
+
+**Key architectural decisions:**
+- Migrated from hook-only to skill-based architecture for significant token reduction on clear prompts
+- Hook auto-discovery: `hooks/hooks.json` at standard location removes need for `hooks` field in `plugin.json`
+- Plugin distributed via severity1-marketplace for easy installation
+- Progressive disclosure pattern chosen to minimize context overhead for the common case (clear prompts)
+
+**Evolution:**
+- Started as embedded evaluation logic in hook script
+- Extracted skill layer to separate evaluation (hook) from enrichment (skill)
+- Added marketplace support for distribution
+<!-- END AUTO-MANAGED -->
+
+<!-- AUTO-MANAGED: best-practices -->
+## Best Practices
+
+- Keep hook script minimal - it runs on every prompt submission
+- Never add heavy imports or network calls to the hook script
+- Reference files should be self-contained so they work when loaded independently
+- Test bypass prefixes whenever modifying hook logic to prevent breaking slash commands
+- When adding new bypass prefixes, update both the hook script and the conventions section
 <!-- END AUTO-MANAGED -->
 
 <!-- MANUAL -->

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/improve-prompt.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/improve-prompt.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/improve-prompt.py",
             "description": "Run the prompt improvement script"
           }
         ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,8 +36,8 @@ def test_plugin_configuration():
 
     config = json.loads(PLUGIN_JSON.read_text())
 
-    # Check version is 0.5.0
-    assert config["version"] == "0.5.0", f"Expected version 0.5.0, got {config['version']}"
+    # Check version is 0.5.1
+    assert config["version"] == "0.5.1", f"Expected version 0.5.1, got {config['version']}"
 
     # Check skills field exists
     assert "skills" in config, "Missing 'skills' field in plugin.json"


### PR DESCRIPTION
## Summary
- Add `python3 || python` fallback in hook command for Windows compatibility
- Refresh CLAUDE.md to auto-memory format, removing ephemeral data (line counts, token counts, version numbers)
- Add git-insights and best-practices sections to CLAUDE.md
- Bump version to v0.5.1

## Test plan
- [x] All 8 hook tests pass
- [x] All 9 skill tests pass
- [x] Integration tests pass (pre-existing `skills` field issue excluded)