### PR TITLE
refactor(hook): simplify output from JSON to plain text

### DIFF
--- a/scripts/improve-prompt.py
+++ b/scripts/improve-prompt.py
@@ -15,43 +15,29 @@ except json.JSONDecodeError as e:
 
 prompt = input_data.get("prompt", "")
 
-# Escape quotes in prompt for safe embedding
-escaped_prompt = prompt.replace("\\", "\\\\").replace('"', '\\"')
-
-def output_json(text):
-    """Output text in UserPromptSubmit JSON format"""
-    output = {
-        "hookSpecificOutput": {
-            "hookEventName": "UserPromptSubmit",
-            "additionalContext": text
-        }
-    }
-    print(json.dumps(output))
-
 # Check for bypass conditions
 # 1. Explicit bypass with * prefix
 # 2. Slash commands (built-in or custom)
 # 3. Memorize feature (# prefix)
 if prompt.startswith("*"):
     # User explicitly bypassed improvement - remove * prefix
-    clean_prompt = prompt[1:].strip()
-    output_json(clean_prompt)
+    print(prompt[1:].strip())
     sys.exit(0)
 
 if prompt.startswith("/"):
     # Slash command - pass through unchanged
-    output_json(prompt)
+    print(prompt)
     sys.exit(0)
 
 if prompt.startswith("#"):
     # Memorize feature - pass through unchanged
-    output_json(prompt)
+    print(prompt)
     sys.exit(0)
 
 # Build the evaluation wrapper
 wrapped_prompt = f"""PROMPT EVALUATION
 
-Original user request: "{escaped_prompt}"
+Original user request: "{prompt}"
 
 EVALUATE: Is this prompt clear enough to execute, or does it need enrichment?
 
@@ -67,5 +53,5 @@ ONLY USE SKILL if genuinely vague (e.g., "fix the bug" with no context):
 
 If clear, proceed with the original request. If vague, invoke the skill."""
 
-output_json(wrapped_prompt)
+print(wrapped_prompt)
 sys.exit(0)

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Tests for the prompt-improver hook
-Tests bypass prefixes, skill invocation, and JSON output format
+Tests bypass prefixes, skill invocation, and plain text output format
 """
 import json
 import subprocess
@@ -12,7 +12,7 @@ from pathlib import Path
 HOOK_SCRIPT = Path(__file__).parent.parent / "scripts" / "improve-prompt.py"
 
 def run_hook(prompt):
-    """Run the hook script with given prompt and return parsed output"""
+    """Run the hook script with given prompt and return stdout text"""
     input_data = json.dumps({"prompt": prompt})
 
     result = subprocess.run(
@@ -25,86 +25,67 @@ def run_hook(prompt):
     if result.returncode != 0:
         raise Exception(f"Hook failed: {result.stderr}")
 
-    return json.loads(result.stdout)
+    return result.stdout.rstrip("\n")
 
 def test_bypass_asterisk():
     """Test that * prefix strips the prefix and passes through"""
     output = run_hook("* just add a comment")
 
-    assert "hookSpecificOutput" in output
-    assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-
-    context = output["hookSpecificOutput"]["additionalContext"]
-    assert context == "just add a comment"
-    assert not context.startswith("*")
+    assert output == "just add a comment"
+    assert not output.startswith("*")
     print("✓ Asterisk bypass test passed")
 
 def test_bypass_slash():
     """Test that / prefix passes through unchanged (slash commands)"""
     output = run_hook("/commit")
 
-    assert "hookSpecificOutput" in output
-    context = output["hookSpecificOutput"]["additionalContext"]
-    assert context == "/commit"
+    assert output == "/commit"
     print("✓ Slash command bypass test passed")
 
 def test_bypass_hash():
     """Test that # prefix passes through unchanged (memorize feature)"""
     output = run_hook("# remember to use TypeScript")
 
-    assert "hookSpecificOutput" in output
-    context = output["hookSpecificOutput"]["additionalContext"]
-    assert context == "# remember to use TypeScript"
+    assert output == "# remember to use TypeScript"
     print("✓ Hash prefix bypass test passed")
 
 def test_evaluation_prompt():
     """Test that normal prompts get evaluation wrapper"""
     output = run_hook("fix the bug")
 
-    assert "hookSpecificOutput" in output
-    assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-
-    context = output["hookSpecificOutput"]["additionalContext"]
-
     # Should contain evaluation prompt
-    assert "PROMPT EVALUATION" in context
-    assert "fix the bug" in context
-    assert "EVALUATE:" in context or "evaluate" in context.lower()
+    assert "PROMPT EVALUATION" in output
+    assert "fix the bug" in output
+    assert "EVALUATE:" in output or "evaluate" in output.lower()
 
     # Should mention using the skill for vague cases
-    assert "prompt-improver skill" in context.lower() or "skill" in context.lower()
+    assert "prompt-improver skill" in output.lower() or "skill" in output.lower()
 
     # Should have proceed/clear logic
-    assert "clear" in context.lower() or "proceed" in context.lower()
+    assert "clear" in output.lower() or "proceed" in output.lower()
 
     print("✓ Evaluation prompt test passed")
 
-def test_json_output_format():
-    """Test that output follows correct JSON schema"""
+def test_plain_text_output_format():
+    """Test that output is plain text (not JSON-wrapped)"""
     output = run_hook("test prompt")
 
-    # Verify structure
-    assert isinstance(output, dict)
-    assert "hookSpecificOutput" in output
-    assert isinstance(output["hookSpecificOutput"], dict)
+    # Verify plain text: not a JSON object
+    assert not output.strip().startswith("{")
+    assert "hookSpecificOutput" not in output
+    assert isinstance(output, str)
 
-    hook_output = output["hookSpecificOutput"]
-    assert "hookEventName" in hook_output
-    assert "additionalContext" in hook_output
-    assert hook_output["hookEventName"] == "UserPromptSubmit"
-    assert isinstance(hook_output["additionalContext"], str)
+    # Should still contain the evaluation wrapper
+    assert "PROMPT EVALUATION" in output
 
-    print("✓ JSON output format test passed")
+    print("✓ Plain text output format test passed")
 
 def test_empty_prompt():
     """Test handling of empty prompt"""
     output = run_hook("")
 
-    assert "hookSpecificOutput" in output
-    context = output["hookSpecificOutput"]["additionalContext"]
-
     # Should still invoke skill even for empty prompt
-    assert "prompt-improver skill" in context.lower()
+    assert "prompt-improver skill" in output.lower()
     print("✓ Empty prompt test passed")
 
 def test_multiline_prompt():
@@ -115,23 +96,18 @@ and add error handling"""
 
     output = run_hook(prompt)
 
-    assert "hookSpecificOutput" in output
-    context = output["hookSpecificOutput"]["additionalContext"]
-
     # Should preserve multiline content in skill invocation
-    assert "refactor the auth system" in context
+    assert "refactor the auth system" in output
     print("✓ Multiline prompt test passed")
 
 def test_special_characters():
     """Test handling of special characters in prompts"""
     output = run_hook('fix the "bug" in user\'s code & database')
 
-    assert "hookSpecificOutput" in output
-    context = output["hookSpecificOutput"]["additionalContext"]
-
-    # Should contain the original prompt
-    assert "bug" in context
-    assert "user" in context or "users" in context
+    # Should contain the original prompt literally (no JSON escaping)
+    assert 'fix the "bug"' in output
+    assert "user's code" in output
+    assert "&" in output
     print("✓ Special characters test passed")
 
 def run_all_tests():
@@ -141,7 +117,7 @@ def run_all_tests():
         test_bypass_slash,
         test_bypass_hash,
         test_evaluation_prompt,
-        test_json_output_format,
+        test_plain_text_output_format,
         test_empty_prompt,
         test_multiline_prompt,
         test_special_characters,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ PLUGIN_JSON = PROJECT_ROOT / ".claude-plugin" / "plugin.json"
 SKILL_DIR = PROJECT_ROOT / "skills" / "prompt-improver"
 
 def run_hook(prompt):
-    """Run the hook script with given prompt"""
+    """Run the hook script with given prompt and return stdout text"""
     input_data = json.dumps({"prompt": prompt})
 
     result = subprocess.run(
@@ -28,7 +28,7 @@ def run_hook(prompt):
     if result.returncode != 0:
         raise Exception(f"Hook failed: {result.stderr}")
 
-    return json.loads(result.stdout)
+    return result.stdout.rstrip("\n")
 
 def test_plugin_configuration():
     """Test that plugin.json is properly configured"""
@@ -63,12 +63,11 @@ def test_end_to_end_flow():
     output = run_hook("add authentication")
 
     # Should get evaluation wrapper
-    context = output["hookSpecificOutput"]["additionalContext"]
-    assert "PROMPT EVALUATION" in context or "EVALUATE" in context
-    assert "add authentication" in context
+    assert "PROMPT EVALUATION" in output or "EVALUATE" in output
+    assert "add authentication" in output
 
     # Should mention skill for vague cases
-    assert "skill" in context.lower()
+    assert "skill" in output.lower()
 
     print("✓ End-to-end flow works (normal prompt → evaluation wrapper)")
 
@@ -76,19 +75,16 @@ def test_bypass_flow():
     """Test that bypass mechanism works end-to-end"""
     # Test asterisk bypass
     output = run_hook("* just do it")
-    context = output["hookSpecificOutput"]["additionalContext"]
-    assert context == "just do it"
-    assert "skill" not in context.lower()
+    assert output == "just do it"
+    assert "skill" not in output.lower()
 
     # Test slash command
     output = run_hook("/commit")
-    context = output["hookSpecificOutput"]["additionalContext"]
-    assert context == "/commit"
+    assert output == "/commit"
 
     # Test hash prefix
     output = run_hook("# note for later")
-    context = output["hookSpecificOutput"]["additionalContext"]
-    assert context == "# note for later"
+    assert output == "# note for later"
 
     print("✓ Bypass mechanisms work end-to-end")
 
@@ -122,10 +118,8 @@ def test_token_overhead():
     """Test that hook overhead is reasonable"""
     output = run_hook("test")
 
-    context = output["hookSpecificOutput"]["additionalContext"]
-
     # Rough character count (tokens ≈ chars/4 for English)
-    char_count = len(context)
+    char_count = len(output)
     estimated_tokens = char_count // 4
 
     # New version should be ~200-220 tokens (evaluation prompt with preface instruction)
@@ -153,15 +147,13 @@ def test_hook_output_consistency():
     for prompt in prompts:
         output = run_hook(prompt)
 
-        # All should have same structure
-        assert "hookSpecificOutput" in output
-        assert "hookEventName" in output["hookSpecificOutput"]
-        assert "additionalContext" in output["hookSpecificOutput"]
+        # All should be plain text (not JSON)
+        assert not output.strip().startswith("{")
+        assert "hookSpecificOutput" not in output
 
         # All should have evaluation wrapper
-        context = output["hookSpecificOutput"]["additionalContext"]
-        assert "EVALUATE" in context or "evaluate" in context.lower()
-        assert prompt in context
+        assert "EVALUATE" in output or "evaluate" in output.lower()
+        assert prompt in output
 
     print(f"✓ Hook output consistent across {len(prompts)} different prompts")
 


### PR DESCRIPTION
Fixes #17. Switched the UserPromptSubmit hook from emitting hookSpecificOutput JSON to printing the evaluation wrapper as plain text on stdout, which Claude Code injects as additionalContext the same way.