### PR TITLE
Release v0.5.2: Subagent-first research dispatch

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt-improver",
   "description": "Intelligent prompt optimization using skill-based architecture. Enriches vague prompts with research-based clarifying questions before Claude Code executes them",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "severity1"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Claude Code Prompt Improver project.
 
+## [0.5.2] - 2026-05-02
+
+### Changed
+- Skill research dispatches via `Task/Explore` subagents for Glob, Grep, WebSearch, WebFetch, and multi-file Read operations
+- Main context reserved for history mining, single-file Reads of user-named files, Bash/git commands, synthesis, and questions
+- Every Explore dispatch carries explicit conversation context (Explore agents have no access to prior turns)
+- README How-It-Works sequence diagram updated to show `Explore` participant and dispatch flow
+- README "Why main session?" section replaced with "Research dispatch model" doctrine
+- Bumped plugin version to 0.5.2
+
 ## [0.5.0] - 2025-12-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,12 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
 - Ground questions in research findings (not generic assumptions)
 - Support 1-6 questions for complex scenarios
 - Use conversation history to avoid redundant exploration
+
+**Tool dispatch model (skill research phase):**
+- Task/Explore is the primary research carrier for broad codebase exploration
+- Glob, Grep, WebSearch, WebFetch, and multi-file Read must be dispatched via Task/Explore - never called directly in main context
+- Bash (git commands) runs in main context only - Explore agents cannot run Bash
+- Explore agents are context-blind (no access to prior conversation turns) - every Explore prompt must include relevant context explicitly
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: git-insights -->
@@ -139,6 +145,8 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
 - Reference files should be self-contained so they work when loaded independently
 - Test bypass prefixes whenever modifying hook logic to prevent breaking slash commands
 - When adding new bypass prefixes, update both the hook script and the conventions section
+- When writing skill research steps, always pass file paths, errors, and prior decisions into every Explore prompt - Explore has no conversation history access
+- Never call Glob, Grep, WebSearch, or WebFetch directly in main skill context - route them through Task/Explore to preserve context isolation
 <!-- END AUTO-MANAGED -->
 
 <!-- MANUAL -->

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ sequenceDiagram
     participant Hook
     participant Claude
     participant Skill
+    participant Explore
     participant Project
 
     User->>Hook: "fix the bug"
@@ -33,8 +34,11 @@ sequenceDiagram
         Claude->>Skill: Invoke prompt-improver skill
         Skill-->>Claude: Research and question guidance
         Claude->>Claude: Create research plan (TodoWrite)
-        Claude->>Project: Execute research (codebase, web, docs)
-        Project-->>Claude: Context
+        Claude->>Explore: Dispatch research (Glob, Grep, Web, multi-file Read)
+        Explore->>Project: Execute search and reads
+        Project-->>Explore: Raw results
+        Explore-->>Claude: Synthesized findings
+        Claude->>Claude: Synthesize, mine history, run git/Bash if needed
         Claude->>User: Ask grounded questions (1-6)
         User->>Claude: Answer
         Claude->>Claude: Execute original request with answers
@@ -199,11 +203,12 @@ Claude proceeds immediately without questions.
 - Detailed guidance available without bloating all prompts
 - Zero context penalty for unused reference materials
 
-**Why main session (not subagent)?**
-- Has conversation history
-- No redundant exploration
-- More transparent
-- More efficient overall
+**Research dispatch model:**
+- Glob, Grep, WebSearch, WebFetch, and multi-file Read route through `Task/Explore` (Haiku-based, separate context window)
+- Main context handles history mining, single-file Reads of user-named files, Bash/git commands, synthesis, and questions
+- Bash stays in main context because Explore agents cannot run shell commands
+- Every Explore dispatch carries explicit conversation context (file paths, errors, prior decisions) since Explore has no access to prior turns
+- Net effect: search noise lives in cheap subagent tokens, decisions live in main-context tokens
 
 **Manual Skill Invocation:**
 You can also invoke the skill manually without the hook:

--- a/skills/prompt-improver/SKILL.md
+++ b/skills/prompt-improver/SKILL.md
@@ -51,6 +51,8 @@ Create a dynamic research plan using TodoWrite before asking questions.
 - NEVER skip research
 - Check conversation history before exploring codebase
 - Questions must be grounded in actual findings, not assumptions or base knowledge
+- Route Glob, Grep, WebSearch, WebFetch, and multi-file Read through `Task/Explore` — never call them directly in main context
+- Include conversation-relevant context (file paths, errors, prior decisions) in every Explore prompt — Explore cannot see prior turns
 
 For detailed research strategies, patterns, and examples, see [references/research-strategies.md](references/research-strategies.md).
 

--- a/skills/prompt-improver/references/research-strategies.md
+++ b/skills/prompt-improver/references/research-strategies.md
@@ -450,42 +450,42 @@ Research:
 
 ### Choosing the Right Tool
 
-**Task/Explore Agent:**
+**Task/Explore Agent (primary research carrier):**
 - Broad exploration needed
 - Understanding architecture
 - Finding similar patterns
 - Complex multi-step research
 
-**Glob:**
+**Glob (dispatched via Task/Explore):**
 - Finding files by name pattern
 - Known file types
 - Specific naming conventions
 
-**Grep:**
+**Grep (dispatched via Task/Explore):**
 - Searching code content
 - Finding function calls
 - Pattern matching
 - TODO/FIXME discovery
 
-**Read:**
+**Read (single user-named file in main; multi-file via Task/Explore):**
 - Reading specific files
 - Documentation review
 - Configuration inspection
 - Package.json analysis
 
-**Bash (git commands):**
+**Bash (git commands) — main context only; Explore cannot run Bash:**
 - Historical context
 - Recent changes
 - Commit messages
 - File history
 
-**WebSearch:**
+**WebSearch (dispatched via Task/Explore):**
 - Current best practices
 - Industry standards
 - Library comparisons
 - Common solutions
 
-**WebFetch:**
+**WebFetch (dispatched via Task/Explore):**
 - Official documentation
 - Specific documentation pages
 - API references

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,8 +36,8 @@ def test_plugin_configuration():
 
     config = json.loads(PLUGIN_JSON.read_text())
 
-    # Check version is 0.5.1
-    assert config["version"] == "0.5.1", f"Expected version 0.5.1, got {config['version']}"
+    # Check version is 0.5.2
+    assert config["version"] == "0.5.2", f"Expected version 0.5.2, got {config['version']}"
 
     # Check skills field exists
     assert "skills" in config, "Missing 'skills' field in plugin.json"


### PR DESCRIPTION
## Summary
- Route skill research (Glob, Grep, WebSearch, WebFetch, multi-file Read) through `Task/Explore` subagents, reserving the main context window for synthesis, history mining, Bash/git, and questions
- Refresh README How-It-Works sequence diagram to show `Explore` participant and dispatch flow
- Replace README "Why main session?" section (which contradicted the new doctrine) with a "Research dispatch model" section
- Auto-memory regenerated CLAUDE.md `patterns` and `best-practices` sections to capture the new dispatch rules
- Bump plugin version to 0.5.2; update CHANGELOG

Closes #18

## Test plan
- [x] All 8 hook tests pass
- [x] All 9 skill tests pass
- [x] Integration tests: 6/7 pass (pre-existing `test_plugin_configuration` failure on `skills` field is unrelated to this PR and existed on main before this work)
- [x] `git diff --stat` matches plan scope (5 files: SKILL.md, research-strategies.md, README.md, CLAUDE.md, plugin.json + CHANGELOG.md + test_integration.py)
- [ ] Dogfood: vague codebase prompt dispatches `Task/Explore` rather than calling Glob/Grep in main context (manual verification post-merge)