### PR TITLE
Cleanup test assertions and backfill v0.5.1 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ All notable changes to the Claude Code Prompt Improver project.
 - README "Why main session?" section replaced with "Research dispatch model" doctrine
 - Bumped plugin version to 0.5.2
 
+## [0.5.1] - 2026-02-14
+
+### Added
+- Windows compatibility: `python3 || python` fallback in hook command
+- Auto-memory configuration for CLAUDE.md maintenance
+- Git insights and best practices sections in CLAUDE.md
+
+### Changed
+- Refreshed CLAUDE.md to auto-memory format, removing ephemeral data (line counts, token counts)
+- Aligned CLAUDE.md section headings with auto-memory template
+
 ## [0.5.0] - 2025-12-13
 
 ### Changed

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,21 +39,11 @@ def test_plugin_configuration():
     # Check version is 0.5.2
     assert config["version"] == "0.5.2", f"Expected version 0.5.2, got {config['version']}"
 
-    # Check skills field exists
-    assert "skills" in config, "Missing 'skills' field in plugin.json"
-    assert isinstance(config["skills"], list), "'skills' should be a list"
-    assert len(config["skills"]) > 0, "'skills' list is empty"
-
     # Check hooks field is NOT present (standard hooks/hooks.json is auto-discovered)
     assert "hooks" not in config, "The 'hooks' field should not be present (standard location is auto-discovered)"
 
-    # Check skill path
-    skill_path = config["skills"][0]
-    assert skill_path == "./skills/prompt-improver", f"Unexpected skill path: {skill_path}"
-
-    # Verify skill directory exists
-    resolved_skill_path = PROJECT_ROOT / skill_path.lstrip("./")
-    assert resolved_skill_path.exists(), f"Skill directory not found: {resolved_skill_path}"
+    # Check skills field is NOT present (standard skills/ directory is auto-discovered)
+    assert "skills" not in config, "The 'skills' field should not be present (standard location is auto-discovered)"
 
     print("✓ Plugin configuration is correct")
 


### PR DESCRIPTION
## Summary
- Remove stale `skills` field assertions from `test_plugin_configuration` (the field was intentionally removed in v0.4.0 for auto-discovery; the test was never updated and failed on every run since)
- Replace with inverse assertion (`"skills" not in config`) paralleling the existing `"hooks" not in config` check, capturing the auto-discovery contract
- Backfill missing v0.5.1 entry in CHANGELOG.md (file previously jumped 0.4.0 -> 0.5.0 -> 0.5.2) using published GitHub release notes as source

No version bump (test + docs cleanup only, no behavior change).

## Test plan
- [x] All 24 tests pass (`pytest tests/`) - first full green in multiple releases
- [x] Skill directory existence still covered by `test_skill.py::test_skill_directory_exists`
- [x] CHANGELOG entries chronologically ordered: 0.5.2 -> 0.5.1 -> 0.5.0 -> 0.4.0