### PR TITLE
Ignore auto-memory dirty-files-* transient state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ Thumbs.db
 *.log
 
 # Claude Code auto-memory state
-.claude/auto-memory/dirty-files
+.claude/auto-memory/dirty-files-*


### PR DESCRIPTION
## Summary
- Update `.gitignore` pattern from `dirty-files` (exact match) to `dirty-files-*` (glob) so per-session UUID-suffixed state files written by the auto-memory agent are properly ignored.

## Test plan
- [x] `git check-ignore` confirms an existing `dirty-files-<uuid>` is matched by the new pattern
- [x] `git status` no longer shows transient session files as untracked