### PR TITLE
Add PreToolUse hook for plan mode readability guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 <!-- AUTO-MANAGED: project-description -->
 ## Overview
 
-A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code executes them. Uses skill-based architecture with hook-level evaluation for efficient prompt clarity assessment.
+A multi-hook plugin that enriches vague prompts and injects plan mode guidance. Uses skill-based architecture with hook-level evaluation for efficient prompt clarity assessment.
 
 **Core functionality:**
 - Intercepts prompts via UserPromptSubmit hook
@@ -13,6 +13,7 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
 - Clear prompts: proceeds immediately with minimal overhead
 - Vague prompts: invokes prompt-improver skill for research and clarification
 - Uses AskUserQuestion tool for targeted clarifying questions (1-6 questions)
+- Injects plan readability guidance via PreToolUse hook on EnterPlanMode
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: build-commands -->
@@ -24,6 +25,7 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
   - Hook tests: `pytest tests/test_hook.py`
   - Skill tests: `pytest tests/test_skill.py`
   - Integration tests: `pytest tests/test_integration.py`
+  - Plan guidance tests: `pytest tests/test_plan_guidance.py`
 
 **Installation:**
 - Add marketplace: `claude plugin marketplace add severity1/severity1-marketplace`
@@ -35,12 +37,15 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
 <!-- AUTO-MANAGED: architecture -->
 ## Architecture
 
-**Hook Layer (scripts/improve-prompt.py):**
-- Evaluation orchestrator - reads stdin JSON, writes stdout JSON
-- Handles bypass prefixes: `*` (skip), `/` (slash commands), `#` (memorize)
-- Wraps prompts with evaluation instructions for clarity assessment
-- Claude evaluates clarity using conversation history
-- If vague: instructs Claude to invoke prompt-improver skill
+**Hook Layer (scripts/):**
+- `improve-prompt.py`: Evaluation orchestrator - reads stdin JSON, writes stdout JSON
+  - Handles bypass prefixes: `*` (skip), `/` (slash commands), `#` (memorize)
+  - Wraps prompts with evaluation instructions for clarity assessment
+  - Claude evaluates clarity using conversation history
+  - If vague: instructs Claude to invoke prompt-improver skill
+- `plan-guidance.py`: Plan mode guidance injector - fires on EnterPlanMode via PreToolUse
+  - Consumes stdin, outputs plan readability guidance as additionalContext
+  - Guidance: keep problem statement, omit decision history (rejected approaches, revision rationale), rewrite entire plan clean on revision (no append/annotation), one action per step with file paths as anchors (e.g., src/auth.ts:42), favor terse action steps
 
 **Skill Layer (skills/prompt-improver/):**
 - `SKILL.md`: Research and question workflow
@@ -53,9 +58,9 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
   - `examples.md`: Real prompt transformations
 
 **Directory structure:**
-- `scripts/` - Hook implementation
+- `scripts/` - Hook implementations (improve-prompt.py, plan-guidance.py)
 - `skills/prompt-improver/` - Skill and reference files
-- `tests/` - Test suite (hook, skill, integration)
+- `tests/` - Test suite (hook, skill, integration, plan_guidance)
 - `hooks/` - Hook configuration (hooks.json, auto-discovered)
 - `.claude-plugin/` - Plugin metadata
 <!-- END AUTO-MANAGED -->
@@ -65,9 +70,15 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
 
 **Hook output format:**
 - JSON structure following Claude Code specification
-- Format: `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "..."}}`
+- UserPromptSubmit format: `{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "..."}}`
+- PreToolUse format: `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "..."}}`
 - Exit code 0 for all success paths
 - Hook commands use `python3 || python` fallback for Windows compatibility
+
+**Plugin auto-discovery:**
+- Do NOT add `hooks` field to `plugin.json` - `hooks/hooks.json` at standard location is auto-discovered
+- Do NOT add `skills` field to `plugin.json` - `skills/` directory at standard location is auto-discovered
+- Integration test `test_plugin_configuration` asserts both fields are absent
 
 **Bypass prefixes:**
 - `*` prefix: Skip evaluation entirely, strip prefix from prompt
@@ -127,14 +138,17 @@ A UserPromptSubmit hook plugin that enriches vague prompts before Claude Code ex
 
 **Key architectural decisions:**
 - Migrated from hook-only to skill-based architecture for significant token reduction on clear prompts
-- Hook auto-discovery: `hooks/hooks.json` at standard location removes need for `hooks` field in `plugin.json`
+- Auto-discovery: both `hooks/hooks.json` and `skills/` at standard locations remove need for `hooks` or `skills` fields in `plugin.json`
 - Plugin distributed via severity1-marketplace for easy installation
 - Progressive disclosure pattern chosen to minimize context overhead for the common case (clear prompts)
+- Added PreToolUse/EnterPlanMode hook to inject plan readability guidance without modifying the skill layer
 
 **Evolution:**
 - Started as embedded evaluation logic in hook script
 - Extracted skill layer to separate evaluation (hook) from enrichment (skill)
 - Added marketplace support for distribution
+- Adopted subagent-first research dispatch: broad exploration (Glob, Grep, WebSearch, WebFetch, multi-file Read) routed through Task/Explore to isolate main context
+- Added plan-guidance.py as a second hook script targeting plan mode entry
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: best-practices -->

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "description": "Injects plan readability guidance when entering plan mode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/plan-guidance.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/plan-guidance.py"
+          }
+        ],
+        "tools": ["EnterPlanMode"]
+      }
     ]
   }
 }

--- a/scripts/plan-guidance.py
+++ b/scripts/plan-guidance.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Plan Mode Guidance Hook
+Injects readability guidance when entering plan mode via PreToolUse on EnterPlanMode.
+"""
+import json
+import sys
+
+# Consume stdin (required by hook protocol, but content is unused)
+try:
+    json.load(sys.stdin)
+except (json.JSONDecodeError, ValueError):
+    pass
+
+guidance = (
+    "Plan readability guidance: "
+    "Keep the problem statement - omit decision history "
+    "(rejected approaches, revision rationale, prior iterations). "
+    "On plan revisions, rewrite the entire plan clean - "
+    "do not append revision notes or annotate what changed. "
+    "Use one action per step with file paths as anchors (e.g., src/auth.ts:42). "
+    "Favor terse action steps over explanatory prose."
+)
+
+output = {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "additionalContext": guidance
+    }
+}
+
+print(json.dumps(output))
+sys.exit(0)

--- a/tests/test_plan_guidance.py
+++ b/tests/test_plan_guidance.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Tests for the plan-guidance hook
+Validates JSON output structure, guidance content, and exit code.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HOOK_SCRIPT = Path(__file__).parent.parent / "scripts" / "plan-guidance.py"
+
+
+def run_hook(input_data="{}"):
+    """Run the plan-guidance hook and return (parsed_output, returncode)"""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=input_data,
+        capture_output=True,
+        text=True
+    )
+    return result
+
+
+def test_output_json_structure():
+    """Test that output follows the hook JSON format"""
+    result = run_hook()
+    assert result.returncode == 0
+
+    output = json.loads(result.stdout)
+    assert "hookSpecificOutput" in output
+    assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert "additionalContext" in output["hookSpecificOutput"]
+
+
+def test_guidance_content():
+    """Test that additionalContext contains plan readability guidance"""
+    result = run_hook()
+    output = json.loads(result.stdout)
+    context = output["hookSpecificOutput"]["additionalContext"]
+
+    assert "decision history" in context
+    assert "rewrite the entire plan clean" in context
+    assert "terse action steps" in context
+    assert "problem statement" in context
+
+
+def test_exit_code_zero():
+    """Test that script exits with code 0"""
+    result = run_hook()
+    assert result.returncode == 0
+
+
+def test_handles_empty_stdin():
+    """Test graceful handling of empty stdin"""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="",
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    assert "hookSpecificOutput" in output
+
+
+def test_handles_invalid_json_stdin():
+    """Test graceful handling of invalid JSON on stdin"""
+    result = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input="not json at all",
+        capture_output=True,
+        text=True
+    )
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    assert "hookSpecificOutput" in output


### PR DESCRIPTION
## Summary

- Adds `scripts/plan-guidance.py` PreToolUse hook that fires on `EnterPlanMode` to inject plan readability guidance
- Guidance: keep problem statement, omit decision history, rewrite clean on revision, one action per step with file path anchors, terse steps
- Registers hook in `hooks/hooks.json` with `tools: ["EnterPlanMode"]` filter
- Adds 5 tests covering JSON structure, content, exit code, and graceful stdin handling

## Test plan

- [x] `pytest tests/test_plan_guidance.py` - 5 tests pass
- [x] `pytest tests/` - full suite 29/29 pass
- [x] `python3 scripts/plan-guidance.py < /dev/null` - outputs valid JSON