### PR TITLE
Release v0.5.3: Plan mode readability guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt-improver",
   "description": "Intelligent prompt optimization using skill-based architecture. Enriches vague prompts with research-based clarifying questions before Claude Code executes them",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": {
     "name": "severity1"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the Claude Code Prompt Improver project.
 
+## [0.5.3] - 2026-05-12
+
+### Added
+- `PreToolUse` hook scoped to `EnterPlanMode` that injects plan readability guidance into the model context
+- `scripts/plan-guidance.py` writes the guidance as `additionalContext` via `hookSpecificOutput`
+- Guidance keeps the problem statement, omits decision history, requires clean rewrites on plan revisions, and favors terse one-action-per-step prose with file paths as anchors
+- `tests/test_plan_guidance.py` covers JSON output shape, guidance content, and stdin handling
+
+### Fixed
+- `hooks/hooks.json` PreToolUse entry now uses the official `matcher` field instead of an unrecognized `tools` array, scoping the plan-guidance hook to `EnterPlanMode` only (previously fired on every tool call because the unknown field was silently ignored)
+
+### Changed
+- Plugin hook count grows from one (`UserPromptSubmit`) to two (`UserPromptSubmit` and `PreToolUse`)
+- Bumped plugin version to 0.5.3
+
 ## [0.5.2] - 2026-05-02
 
 ### Changed

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,13 +15,13 @@
     "PreToolUse": [
       {
         "description": "Injects plan readability guidance when entering plan mode",
+        "matcher": "EnterPlanMode",
         "hooks": [
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/plan-guidance.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/plan-guidance.py"
           }
-        ],
-        "tools": ["EnterPlanMode"]
+        ]
       }
     ]
   }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,8 +36,8 @@ def test_plugin_configuration():
 
     config = json.loads(PLUGIN_JSON.read_text())
 
-    # Check version is 0.5.2
-    assert config["version"] == "0.5.2", f"Expected version 0.5.2, got {config['version']}"
+    # Check version is 0.5.3
+    assert config["version"] == "0.5.3", f"Expected version 0.5.3, got {config['version']}"
 
     # Check hooks field is NOT present (standard hooks/hooks.json is auto-discovered)
     assert "hooks" not in config, "The 'hooks' field should not be present (standard location is auto-discovered)"


### PR DESCRIPTION
## Summary
- Bumps plugin to v0.5.3 (aligns the manifest with the existing `v0.5.3` git tag that previously pointed at a `0.5.2` manifest)
- Fixes the `PreToolUse` hook matcher in `hooks/hooks.json`: replaces the unrecognized `tools: ["EnterPlanMode"]` field with the official `matcher: "EnterPlanMode"`, scoping the plan-guidance hook to `EnterPlanMode` only (it was previously firing on every tool call because the unknown field was silently dropped)
- Adds a 0.5.3 entry to `CHANGELOG.md` documenting the new `PreToolUse` hook, the matcher fix, and the hook-count bump
- Updates the `tests/test_integration.py` version assertion to `0.5.3`

## Why this is bundled
The matcher bug ships in the same commits that introduced the new hook (#38), so users on the cached `v0.5.3` snapshot today see the guidance injected before every tool call. Bundling the manifest bump and the matcher fix makes 0.5.3 the first release where the feature actually works as designed.

## Test plan
- [x] `pytest tests/` (29 passed locally)
- [ ] Verify cache refresh after merge: `claude plugin update prompt-improver@severity1-marketplace` then `/reload-plugins`
- [ ] Confirm the `PreToolUse:EnterPlanMode` hook fires on `EnterPlanMode` only (not on Bash/Read/Edit/etc.)
- [ ] Confirm `/plugin` reports `prompt-improver` at version `0.5.3`

## Follow-up after merge
The `v0.5.3` git tag currently points at `07e2a61` (the pre-bump commit). After this PR merges, retag:
```
git tag -d v0.5.3
git tag v0.5.3                # on the new merge commit with manifest = 0.5.3
git push origin v0.5.3 --force
```