### PR TITLE
Add workflow-guidance hook for model-routing guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt-improver",
   "description": "Intelligent prompt optimization using skill-based architecture. Enriches vague prompts with research-based clarifying questions before Claude Code executes them",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": {
     "name": "severity1"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ All notable changes to the Claude Code Prompt Improver project.
 - `scripts/workflow-guidance.py`: a second `UserPromptSubmit` hook that injects model-routing and plan-mode-first HITL guidance when a dynamic workflow is requested
 - Triggers on the `workflow`/`workflows` keyword, the `/deep-research` command, `/effort ultracode`, and saved workflow commands found under `.claude/workflows/` (cwd) or `~/.claude/workflows/`
 - Guidance is model-agnostic: it reserves the session model for planning, strategy, and orchestration and routes implementation to a smaller, cheaper model; `/effort ultracode` appends a clause applying the routing session-wide
-- `tests/test_workflow_guidance.py` covers trigger detection, the `*` bypass, path-traversal safety, empty/invalid stdin, and the guidance token budget
+- `tests/test_workflow_guidance.py` covers trigger detection, the `*` and `#` bypass prefixes, the `/workflows` no-output case, the conditional guard, path-traversal safety, empty/invalid stdin, and the guidance token budget
+
+### Fixed
+- `#` (memorize) prefix now bypasses the workflow-guidance hook, mirroring `improve-prompt.py`, so a prompt like "# remember the deploy workflow doc" no longer false-triggers
+- Natural-language keyword search restricted to non-slash prompts so the `/workflows` run-management command no longer false-triggers (slash prompts keep explicit `/deep-research`, `/effort ultracode`, and saved-workflow detection)
+- `CORE_GUIDANCE` now leads with a conditional ("If this prompt will run as a dynamic workflow...") so broad keyword matches like "fix the CI workflow file" self-cancel at the model rather than injecting inert guidance
 
 ### Changed
 - Plugin now registers two `UserPromptSubmit` hooks (`improve-prompt.py` and `workflow-guidance.py`) alongside the `PreToolUse` plan-guidance hook

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Claude Code Prompt Improver project.
 
+## [0.5.4] - 2026-05-29
+
+### Added
+- `scripts/workflow-guidance.py`: a second `UserPromptSubmit` hook that injects model-routing and plan-mode-first HITL guidance when a dynamic workflow is requested
+- Triggers on the `workflow`/`workflows` keyword, the `/deep-research` command, `/effort ultracode`, and saved workflow commands found under `.claude/workflows/` (cwd) or `~/.claude/workflows/`
+- Guidance is model-agnostic: it reserves the session model for planning, strategy, and orchestration and routes implementation to a smaller, cheaper model; `/effort ultracode` appends a clause applying the routing session-wide
+- `tests/test_workflow_guidance.py` covers trigger detection, the `*` bypass, path-traversal safety, empty/invalid stdin, and the guidance token budget
+
+### Changed
+- Plugin now registers two `UserPromptSubmit` hooks (`improve-prompt.py` and `workflow-guidance.py`) alongside the `PreToolUse` plan-guidance hook
+- Bumped plugin version to 0.5.4
+
 ## [0.5.3] - 2026-05-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ A multi-hook plugin that enriches vague prompts and injects plan mode guidance. 
 - Vague prompts: invokes prompt-improver skill for research and clarification
 - Uses AskUserQuestion tool for targeted clarifying questions (1-6 questions)
 - Injects plan readability guidance via PreToolUse hook on EnterPlanMode
+- Injects model-routing and plan-mode-first HITL guidance via second UserPromptSubmit hook for workflow/deep-research/ultracode requests
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: build-commands -->
@@ -26,6 +27,7 @@ A multi-hook plugin that enriches vague prompts and injects plan mode guidance. 
   - Skill tests: `pytest tests/test_skill.py`
   - Integration tests: `pytest tests/test_integration.py`
   - Plan guidance tests: `pytest tests/test_plan_guidance.py`
+  - Workflow guidance tests: `pytest tests/test_workflow_guidance.py`
 
 **Installation:**
 - Add marketplace: `claude plugin marketplace add severity1/severity1-marketplace`
@@ -46,6 +48,9 @@ A multi-hook plugin that enriches vague prompts and injects plan mode guidance. 
 - `plan-guidance.py`: Plan mode guidance injector - fires on EnterPlanMode via PreToolUse
   - Consumes stdin, outputs plan readability guidance as additionalContext
   - Guidance: keep problem statement, omit decision history (rejected approaches, revision rationale), rewrite entire plan clean on revision (no append/annotation), one action per step with file paths as anchors (e.g., src/auth.ts:42), favor terse action steps
+- `workflow-guidance.py`: Workflow routing injector - second UserPromptSubmit hook, fires only when a dynamic workflow is requested
+  - Triggers on the `workflow`/`workflows` keyword, `/deep-research`, `/effort ultracode`, and saved workflow commands under `.claude/workflows/` (cwd) or `~/.claude/workflows/`
+  - `*` bypass and non-slash prompts skip filesystem scanning; emits model-agnostic routing guidance (session model for planning/orchestration, smaller cheaper model for implementation) plus advisory plan-mode-first HITL; silent on every non-workflow prompt
 
 **Skill Layer (skills/prompt-improver/):**
 - `SKILL.md`: Research and question workflow
@@ -58,9 +63,9 @@ A multi-hook plugin that enriches vague prompts and injects plan mode guidance. 
   - `examples.md`: Real prompt transformations
 
 **Directory structure:**
-- `scripts/` - Hook implementations (improve-prompt.py, plan-guidance.py)
+- `scripts/` - Hook implementations (improve-prompt.py, plan-guidance.py, workflow-guidance.py)
 - `skills/prompt-improver/` - Skill and reference files
-- `tests/` - Test suite (hook, skill, integration, plan_guidance)
+- `tests/` - Test suite (hook, skill, integration, plan_guidance, workflow_guidance)
 - `hooks/` - Hook configuration (hooks.json, auto-discovered)
 - `.claude-plugin/` - Plugin metadata
 <!-- END AUTO-MANAGED -->
@@ -142,6 +147,7 @@ A multi-hook plugin that enriches vague prompts and injects plan mode guidance. 
 - Plugin distributed via severity1-marketplace for easy installation
 - Progressive disclosure pattern chosen to minimize context overhead for the common case (clear prompts)
 - Added PreToolUse/EnterPlanMode hook to inject plan readability guidance without modifying the skill layer
+- Added workflow-guidance.py as a third hook script (second UserPromptSubmit) for model-routing and HITL guidance on workflow/deep-research/ultracode requests; silent on all other prompts
 
 **Evolution:**
 - Started as embedded evaluation logic in hook script
@@ -149,6 +155,7 @@ A multi-hook plugin that enriches vague prompts and injects plan mode guidance. 
 - Added marketplace support for distribution
 - Adopted subagent-first research dispatch: broad exploration (Glob, Grep, WebSearch, WebFetch, multi-file Read) routed through Task/Explore to isolate main context
 - Added plan-guidance.py as a second hook script targeting plan mode entry
+- Added workflow-guidance.py as a third hook script injecting model-routing guidance for dynamic workflow requests; uses saved-workflow filesystem scan gated behind leading "/" to avoid I/O on non-slash prompts
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: best-practices -->
@@ -161,6 +168,8 @@ A multi-hook plugin that enriches vague prompts and injects plan mode guidance. 
 - When adding new bypass prefixes, update both the hook script and the conventions section
 - When writing skill research steps, always pass file paths, errors, and prior decisions into every Explore prompt - Explore has no conversation history access
 - Never call Glob, Grep, WebSearch, or WebFetch directly in main skill context - route them through Task/Explore to preserve context isolation
+- workflow-guidance.py gates filesystem scanning behind a leading "/" check - non-slash prompts do zero I/O; preserve this pattern when adding new trigger conditions
+- When adding new bypass prefixes to workflow-guidance.py, mirror the `*` prefix check at the top of main() before any trigger evaluation
 <!-- END AUTO-MANAGED -->
 
 <!-- MANUAL -->

--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ Claude proceeds immediately without questions.
 - Claude evaluates clarity using conversation history
 - If vague: Instructs Claude to invoke `prompt-improver` skill
 
+**Hook (scripts/workflow-guidance.py) - Workflow Routing Guidance:**
+- Second `UserPromptSubmit` hook; fires only when a dynamic workflow is requested
+- Triggers on the `workflow`/`workflows` keyword, `/deep-research`, `/effort ultracode`, and saved workflow commands under `.claude/workflows/` (cwd) or `~/.claude/workflows/`
+- The `*` bypass prefix and non-slash prompts skip all filesystem scanning
+- Injects model-agnostic routing guidance: reserve the session model for planning, strategy, and orchestration; route implementation to a smaller, cheaper model
+- Advises plan-mode-first as extra human review before a multi-agent run (advisory, not a replacement for the workflow's own approval gate)
+- `/effort ultracode` appends a clause applying the routing to every task that session
+- Silent on every non-workflow prompt (zero output), so the only cost lands where a multi-agent run is about to begin
+
 **Skill (skills/prompt-improver/) - Research & Question Logic:**
 - **SKILL.md**: Research and question workflow (~170 lines)
   - Assumes prompt already determined vague by hook

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Claude proceeds immediately without questions.
 - Advises plan-mode-first as extra human review before a multi-agent run (advisory, not a replacement for the workflow's own approval gate)
 - `/effort ultracode` appends a clause applying the routing to every task that session
 - Silent on every non-workflow prompt (zero output), so the only cost lands where a multi-agent run is about to begin
+- **Known limitation:** the keyword filter biases toward recall, so a non-launch mention of "workflow" (e.g., "fix the CI workflow file") may inject inert guidance that the model ignores via the conditional guard. No hook can see the post-prompt workflow decision.
 
 **Skill (skills/prompt-improver/) - Research & Question Logic:**
 - **SKILL.md**: Research and question workflow (~170 lines)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,6 +10,15 @@
             "description": "Run the prompt improvement script"
           }
         ]
+      },
+      {
+        "description": "Injects model-routing guidance when a dynamic workflow is requested",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/workflow-guidance.py || python ${CLAUDE_PLUGIN_ROOT}/scripts/workflow-guidance.py"
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/scripts/workflow-guidance.py
+++ b/scripts/workflow-guidance.py
@@ -10,12 +10,17 @@ import sys
 from pathlib import Path
 
 # Static guidance directed at Claude (the context reader).
-# Names token efficiency as the goal, then the principle, then concrete routing.
+# Leads with a condition so false positives self-cancel at the model: the hook
+# is a high-recall regex filter with no workflow signal in its input, so it
+# cannot distinguish "build a workflow" from "fix the CI workflow file". That
+# residual ambiguity is intentionally deferred to the model reading the context.
 CORE_GUIDANCE = (
-    "Enter plan mode first and show the plan before running. "
+    "If this prompt will run as a dynamic workflow: "
+    "enter plan mode first and show the plan before running. "
     "For token efficiency, use models suited to each stage: "
     "reserve the session model for planning, strategy, and orchestration; "
-    "route implementation to a smaller, cheaper model."
+    "route implementation to a smaller, cheaper model. "
+    "If this is not a workflow, ignore this guidance."
 )
 
 # Appended only for /effort ultracode, which makes every task a workflow.
@@ -67,13 +72,21 @@ def main():
     if stripped.startswith("*"):
         sys.exit(0)
 
+    # Memorize feature (# prefix) - mirrors improve-prompt.py's # bypass so a
+    # prompt like "# remember the deploy workflow doc" does not false-trigger.
+    if stripped.startswith("#"):
+        sys.exit(0)
+
     is_ultracode = bool(EFFORT_ULTRACODE.match(stripped))
 
-    # Saved-workflow scan is gated behind a leading "/" so non-slash prompts
-    # do zero filesystem I/O.
+    # The natural-language keyword search runs on non-slash prompts only.
+    # Slash prompts keep their explicit detection (/deep-research,
+    # /effort ultracode, saved-workflow scan), so run-management commands like
+    # /workflows no longer keyword-trigger. The saved-workflow scan is gated
+    # behind a leading "/" so non-slash prompts do zero filesystem I/O.
     triggered = (
         is_ultracode
-        or bool(WORKFLOW_KEYWORD.search(prompt))
+        or (not stripped.startswith("/") and bool(WORKFLOW_KEYWORD.search(prompt)))
         or bool(DEEP_RESEARCH.match(stripped))
         or (stripped.startswith("/") and saved_workflow_exists(stripped))
     )

--- a/scripts/workflow-guidance.py
+++ b/scripts/workflow-guidance.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Workflow Guidance Hook
+Injects model-routing and plan-mode-first HITL guidance when a dynamic
+workflow is requested, via UserPromptSubmit.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+# Static guidance directed at Claude (the context reader).
+# Names token efficiency as the goal, then the principle, then concrete routing.
+CORE_GUIDANCE = (
+    "Enter plan mode first and show the plan before running. "
+    "For token efficiency, use models suited to each stage: "
+    "reserve the session model for planning, strategy, and orchestration; "
+    "route implementation to a smaller, cheaper model."
+)
+
+# Appended only for /effort ultracode, which makes every task a workflow.
+ULTRACODE_CLAUSE = " Under ultracode, apply this routing to every task this session."
+
+WORKFLOW_KEYWORD = re.compile(r"\bworkflows?\b", re.IGNORECASE)
+DEEP_RESEARCH = re.compile(r"^/deep-research\b", re.IGNORECASE)
+EFFORT_ULTRACODE = re.compile(r"^/effort\s+ultracode\b", re.IGNORECASE)
+# Strict leading-token capture; path-traversal input fails to match.
+WORKFLOW_NAME = re.compile(r"^/([A-Za-z0-9_:-]+)")
+
+WORKFLOW_DIRS = (
+    Path.cwd() / ".claude" / "workflows",
+    Path.home() / ".claude" / "workflows",
+)
+
+
+def saved_workflow_exists(stripped):
+    """Check known workflow dirs for a file matching the leading /name token."""
+    match = WORKFLOW_NAME.match(stripped)
+    if not match:
+        return False
+    name = match.group(1)
+    for directory in WORKFLOW_DIRS:
+        try:
+            if any(directory.glob(f"{name}.*")):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def main():
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if not isinstance(input_data, dict):
+        sys.exit(0)
+
+    prompt = input_data.get("prompt", "")
+    if not isinstance(prompt, str) or not prompt:
+        sys.exit(0)
+
+    stripped = prompt.lstrip()
+
+    # Explicit bypass with * prefix
+    if stripped.startswith("*"):
+        sys.exit(0)
+
+    is_ultracode = bool(EFFORT_ULTRACODE.match(stripped))
+
+    # Saved-workflow scan is gated behind a leading "/" so non-slash prompts
+    # do zero filesystem I/O.
+    triggered = (
+        is_ultracode
+        or bool(WORKFLOW_KEYWORD.search(prompt))
+        or bool(DEEP_RESEARCH.match(stripped))
+        or (stripped.startswith("/") and saved_workflow_exists(stripped))
+    )
+
+    if not triggered:
+        sys.exit(0)
+
+    context = CORE_GUIDANCE
+    if is_ultracode:
+        context += ULTRACODE_CLAUSE
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": context,
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -36,8 +36,8 @@ def test_plugin_configuration():
 
     config = json.loads(PLUGIN_JSON.read_text())
 
-    # Check version is 0.5.3
-    assert config["version"] == "0.5.3", f"Expected version 0.5.3, got {config['version']}"
+    # Check version is 0.5.4
+    assert config["version"] == "0.5.4", f"Expected version 0.5.4, got {config['version']}"
 
     # Check hooks field is NOT present (standard hooks/hooks.json is auto-discovered)
     assert "hooks" not in config, "The 'hooks' field should not be present (standard location is auto-discovered)"

--- a/tests/test_workflow_guidance.py
+++ b/tests/test_workflow_guidance.py
@@ -54,6 +54,19 @@ def test_plural_keyword_triggers():
     assert "orchestration" in context
 
 
+def test_workflows_management_command_no_output():
+    """/workflows is a run-management command, not a launch trigger (#2)"""
+    result = run_hook("/workflows")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_conditional_guard_present():
+    """A keyword trigger's context leads with the conditional guard (#3)"""
+    context = parse(run_hook("build a workflow to migrate 500 files"))
+    assert context.startswith("If this prompt will run as a dynamic workflow")
+
+
 def test_deep_research_command_triggers():
     """The /deep-research command triggers guidance"""
     context = parse(run_hook("/deep-research the auth subsystem"))
@@ -111,6 +124,13 @@ def test_non_workflow_prompt_no_output():
 def test_bypass_prefix_no_output():
     """The * bypass prefix suppresses output even for workflow prompts"""
     result = run_hook("* build a workflow")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_hash_bypass_no_output():
+    """The # memorize prefix suppresses output even for workflow prompts (#1)"""
+    result = run_hook("# remember the deploy workflow doc")
     assert result.returncode == 0
     assert result.stdout.strip() == ""
 

--- a/tests/test_workflow_guidance.py
+++ b/tests/test_workflow_guidance.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Tests for the workflow-guidance hook
+Validates trigger detection, bypass, guidance content, exit codes, and token budget.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HOOK_SCRIPT = Path(__file__).parent.parent / "scripts" / "workflow-guidance.py"
+
+
+def run_hook(prompt=None, raw=None, cwd=None, env=None):
+    """Run the workflow-guidance hook and return the CompletedProcess.
+
+    Pass `prompt` to send {"prompt": ...} JSON, or `raw` to send raw stdin.
+    """
+    if raw is not None:
+        input_data = raw
+    else:
+        input_data = json.dumps({"prompt": prompt})
+
+    return subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=input_data,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+
+
+def parse(result):
+    """Assert success and return the parsed additionalContext string."""
+    assert result.returncode == 0
+    output = json.loads(result.stdout)
+    assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    return output["hookSpecificOutput"]["additionalContext"]
+
+
+def test_keyword_triggers():
+    """A prompt containing 'workflow' triggers routing guidance"""
+    context = parse(run_hook("build a workflow to migrate 500 files"))
+    assert "orchestration" in context
+    assert "implementation" in context
+
+
+def test_plural_keyword_triggers():
+    """The plural 'workflows' also triggers"""
+    context = parse(run_hook("compare dynamic workflows for this repo"))
+    assert "orchestration" in context
+
+
+def test_deep_research_command_triggers():
+    """The /deep-research command triggers guidance"""
+    context = parse(run_hook("/deep-research the auth subsystem"))
+    assert "implementation" in context
+
+
+def test_effort_ultracode_triggers_with_clause():
+    """/effort ultracode triggers and appends the session-wide clause"""
+    context = parse(run_hook("/effort ultracode"))
+    assert "every task" in context
+
+
+def test_non_ultracode_omits_clause():
+    """Non-ultracode triggers do not include the ultracode clause"""
+    context = parse(run_hook("build a workflow to refactor"))
+    assert "every task" not in context
+
+
+def test_saved_workflow_scan():
+    """A saved workflow file under .claude/workflows triggers detection"""
+    with tempfile.TemporaryDirectory() as tmp:
+        workflows = Path(tmp) / ".claude" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "myflow.md").write_text("# saved workflow\n")
+
+        # HOME override isolates both scan dirs to the tmp tree.
+        env = {**os.environ, "HOME": tmp}
+
+        triggered = run_hook("/myflow run it", cwd=tmp, env=env)
+        context = parse(triggered)
+        assert "orchestration" in context
+
+        not_triggered = run_hook("/notaflow run it", cwd=tmp, env=env)
+        assert not_triggered.returncode == 0
+        assert not_triggered.stdout.strip() == ""
+
+
+def test_path_traversal_does_not_trigger():
+    """Path-traversal slash input does not trigger and does not raise"""
+    with tempfile.TemporaryDirectory() as tmp:
+        env = {**os.environ, "HOME": tmp}
+        result = run_hook("/../../etc/passwd", cwd=tmp, env=env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+        assert result.stderr.strip() == ""
+
+
+def test_non_workflow_prompt_no_output():
+    """An ordinary prompt produces no output"""
+    result = run_hook("add a comment to utils.py")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_bypass_prefix_no_output():
+    """The * bypass prefix suppresses output even for workflow prompts"""
+    result = run_hook("* build a workflow")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_empty_stdin_exits_zero():
+    """Empty stdin exits 0 with no output"""
+    result = run_hook(raw="")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_invalid_json_stdin_exits_zero():
+    """Invalid JSON stdin exits 0 with no output"""
+    result = run_hook(raw="not json at all")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_token_budget():
+    """Guidance string stays within the token budget"""
+    context = parse(run_hook("/effort ultracode"))
+    assert len(context.split()) < 110


### PR DESCRIPTION
## Summary
- Adds `scripts/workflow-guidance.py`, a second `UserPromptSubmit` hook that injects model-routing and plan-mode-first HITL guidance when a dynamic workflow is requested
- Triggers on the `workflow`/`workflows` keyword, `/deep-research`, `/effort ultracode`, and saved workflow commands found under `.claude/workflows/` (cwd) or `~/.claude/workflows/`
- Guidance is model-agnostic: reserve the session model for planning, strategy, and orchestration; route implementation to a smaller, cheaper model. `/effort ultracode` appends a clause applying the routing session-wide
- The `*` bypass prefix and non-slash prompts skip all filesystem scanning; the hook is silent on every non-workflow prompt
- Bumps plugin version `0.5.3` to `0.5.4`; updates CHANGELOG, README, and CLAUDE.md

## Test plan
- [ ] `pytest tests/` is green (41 tests, including new `tests/test_workflow_guidance.py`)
- [ ] Manual keyword: `echo '{"prompt":"build a workflow to migrate 500 files"}' | python3 scripts/workflow-guidance.py` returns routing guidance JSON
- [ ] Manual ultracode: `echo '{"prompt":"/effort ultracode"}' | python3 scripts/workflow-guidance.py` includes the session-wide clause
- [ ] Manual path-traversal: `echo '{"prompt":"/../../etc/passwd"}' | python3 scripts/workflow-guidance.py` returns empty stdout, exit 0, no traceback
- [ ] Manual negative: `echo '{"prompt":"fix typo in readme"}' | python3 scripts/workflow-guidance.py` returns empty stdout, exit 0
- [ ] Manual bypass: `echo '{"prompt":"* build a workflow"}' | python3 scripts/workflow-guidance.py` returns empty stdout, exit 0