### PR TITLE
Add ask-user-question and plan-mode nudges

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prompt-improver",
-  "description": "Intelligent prompt optimization: injects the right context at the right moment so Claude lands a better first output. Clarifies vague prompts with research-based questions, plus targeted nudges for approach selection, plan readability, workflow routing, background execution, subagent routing, and output readability",
-  "version": "0.6.0",
+  "description": "Intelligent prompt optimization: injects the right context at the right moment so Claude lands a better first output. Clarifies vague prompts with research-based questions, plus targeted nudges for approach selection, plan readability, workflow routing, background execution, subagent routing, output readability, user-decision questions, and plan-mode assessment",
+  "version": "0.6.1",
   "author": {
     "name": "severity1"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Claude Code Prompt Improver project.
 
+## [0.6.1] - 2026-06-03
+
+### Added
+- `ask-user-question` nudge (`nudges/UserPromptSubmit/40-ask-user-question.json`): keyword-gated on decision/fork language (which/should/prefer/choose/decide/options/recommend/better/vs/trade-offs/pick). Routes genuine user-owned decisions through the `AskUserQuestion` tool with concrete options so the user can think critically, grounds questions in research when context is thin, and defers to a sensible default for minor or reversible choices. Self-cancels false positives via a leading condition
+- `plan-mode` nudge (`nudges/UserPromptSubmit/50-plan-mode.json`): `non_slash`-only criteria with no `match` patterns, so it always evaluates. Injects an eval-then-branch instruction - judge whether the task is complex, multi-step, ambiguous, or architectural enough to warrant a reviewed plan, enter plan mode if so, otherwise proceed. Complexity is not lexical, so it cannot be keyword-gated; the open gate evaluates every task regardless of wording while the engine's default bypass keeps `*`/`#`/empty silent
+- `tests/test_engine.py` gains a plan-mode pair (always-fires on a no-keyword prompt, stays silent under `*` bypass) and an `ask-user-question` pair (fires on decision language, silent on a plain prompt)
+
+### Changed
+- `approach-assessment` nudge: trimmed the plan line from its guidance text and description so it owns "which approach" (subagent vs orchestration vs just do it) while `plan-mode` owns "whether to plan at all"; the two no longer overlap
+- Bumped plugin version to 0.6.1
+
 ## [0.5.4] - 2026-05-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,14 @@ A declarative hook engine driven by a JSON nudge registry. One engine dispatches
 - One engine entry point (`engine.py <EventName>`) dispatched per hook event from `hooks.json`
 - Reads stdin once, runs the event's rules, merges `inject_context` fragments by priority, emits one JSON object, exits 0 always
 - `improve` nudge (always fires on UserPromptSubmit): evaluates clarity; clear prompts proceed, vague prompts invoke the prompt-improver skill
-- `approach-assessment` nudge (UserPromptSubmit, priority 10, keyword match on non-trivial-work verbs, non_slash, ignorecase): injects approach-selection guidance (plan vs subagent vs orchestration vs just do it) and reminds that spawned subagents need context passed explicitly; self-cancels false positives with a leading condition
+- `approach-assessment` nudge (UserPromptSubmit, priority 10, keyword match on non-trivial-work verbs, non_slash, ignorecase): injects approach-selection guidance (subagent vs orchestration vs just do it) and reminds that spawned subagents need context passed explicitly; self-cancels false positives with a leading condition
 - `workflow` nudge (UserPromptSubmit, priority 20): injects model-routing and plan-mode-first HITL guidance for workflow/deep-research/ultracode requests
+- `plan-mode` nudge (UserPromptSubmit, priority 50, non_slash, always-evaluate): judges whether task complexity warrants entering plan mode before starting; owns the 'whether to plan at all' decision; approach-assessment owns 'which approach'
 - `plan` nudge (PreToolUse, self-gates on tool_name=EnterPlanMode): injects plan readability guidance
 - `subagent-routing` nudge (SubagentStart): injects breadth-over-depth guidance when an Explore or Plan agent spawns
 - `background-exec` nudge (PreToolUse, matches tool_input.command on Bash): encourages background execution and token-efficient polling for long-running/never-exiting commands
 - `output-readability` nudge (UserPromptSubmit, keyword match): self-cancelling reminder to make substantial deliverables (report/review/summary/analysis) human-parsable
+- `ask-user-question` nudge (UserPromptSubmit, priority 40, keyword match on decision/fork language, non_slash, ignorecase): self-cancelling nudge to route genuine user-owned decisions through AskUserQuestion tool with concrete options; research first when context is thin; pick sensible default for minor/reversible choices
 - Uses AskUserQuestion tool for targeted clarifying questions (1-6 questions)
 <!-- END AUTO-MANAGED -->
 
@@ -60,9 +62,11 @@ A declarative hook engine driven by a JSON nudge registry. One engine dispatches
 
 **Nudge Registry (nudges/<EventName>/*.json):**
 - `nudges/UserPromptSubmit/00-improve.json` - `improve` handler, always-fires clarity wrapper
-- `nudges/UserPromptSubmit/10-approach-assessment.json` - pure data, priority 10, keyword match on non-trivial-work verbs (implement/build/refactor/migrate/redesign/rewrite/integrate/set up/across/multiple), non_slash, ignorecase, approach-selection guidance + subagent context reminder
+- `nudges/UserPromptSubmit/10-approach-assessment.json` - pure data, priority 10, keyword match on non-trivial-work verbs (implement/build/refactor/migrate/redesign/rewrite/integrate/set up/across/multiple), non_slash, ignorecase, approach-selection guidance (subagent/orchestration/just-do-it) + subagent context reminder; plan judgment removed (owned by plan-mode nudge)
 - `nudges/UserPromptSubmit/20-workflow.json` - `workflow` handler, priority 20, workflow routing guidance
 - `nudges/UserPromptSubmit/30-output-readability.json` - pure data, keyword match, self-cancelling human-parsable-deliverable reminder
+- `nudges/UserPromptSubmit/40-ask-user-question.json` - pure data, priority 40, keyword match on decision/fork language (which/should/prefer/choose/decide/decision/options/recommend/better/versus/vs/trade-offs/pick), non_slash, ignorecase, AskUserQuestion routing + research-first + sensible-default guidance
+- `nudges/UserPromptSubmit/50-plan-mode.json` - pure data, non_slash only (no match patterns = always evaluates), priority 50, plan-mode judgment nudge - instructs model to self-assess complexity and enter plan mode if warranted; self-cancels on trivial tasks; owns "whether to plan at all"
 - `nudges/PreToolUse/00-plan.json` - pure data, self-gates on match_target tool_name=EnterPlanMode, plan readability guidance
 - `nudges/PreToolUse/10-background-exec.json` - pure data, match_target command (tool_input.command on Bash), background-execution + token-efficiency guidance
 - `nudges/SubagentStart/00-subagent-routing.json` - pure data, match_target agent_type, breadth-over-depth guidance for Explore/Plan agents
@@ -134,6 +138,8 @@ A declarative hook engine driven by a JSON nudge registry. One engine dispatches
   - `test_drop_in_fixture_nudge_fires_end_to_end`: writes a fixture nudge JSON, verifies it fires on trigger and is absent on non-match, cleans up in finally (extensibility guarantee)
   - `test_append_when_respects_match_target`: fixture nudge with `match_target=agent_type` and `append_when`; verifies appended text appears when agent_type matches (issue #3)
   - `test_approach_assessment_fires_on_complexity_keyword` / `test_approach_assessment_silent_on_trivial_prompt`: verify approach-assessment nudge fires on non-trivial-work verbs and stays silent on trivial prompts
+  - `test_ask_user_question_fires_on_decision_keyword` / `test_ask_user_question_silent_on_plain_prompt`: verify ask-user-question nudge fires on decision/fork language and stays silent on plain prompts
+  - `test_plan_mode_evaluates_on_any_prompt` / `test_plan_mode_silent_on_bypass`: verify plan-mode nudge fires on every non-bypass prompt (including trivial ones) and stays silent on `*` prefix bypass
 - Builtins tests unit-test `improve`/`workflow`/`saved_workflow_exists` in-process
 - Rules tests cover `validate_rule` rejection cases, the capability matrix, and the loader
 - Skill tests validate file structure, frontmatter, and references
@@ -200,6 +206,8 @@ A declarative hook engine driven by a JSON nudge registry. One engine dispatches
 - Reorganized nudges/ from flat (`nudges/*.json`) to per-event subdirectories (`nudges/<EventName>/*.json`); the loader now globs recursively and enforces that each rule's `event` field matches its parent directory name - files loose in `nudges/` root are skipped; deleted `nudges/mcp-tools.json`
 - Added output-readability nudge (UserPromptSubmit, keyword match, self-cancelling); moved background-exec from UserPromptSubmit to PreToolUse/Bash so it fires only when a Bash command is actually about to run - PreToolUse matcher now covers both EnterPlanMode and Bash
 - Swapped merge priority of approach-assessment and workflow nudges on UserPromptSubmit: approach-assessment (general approach-selection guidance) now fires at priority 10 before workflow (narrow orchestration specialization) at priority 20; files renamed to match (10-approach-assessment.json, 20-workflow.json)
+- Added ask-user-question nudge (UserPromptSubmit, priority 40, keyword match on decision/fork language): routes genuine user-owned ambiguous forks through AskUserQuestion with concrete options; research-first when context is thin; pick sensible default for minor choices - extends the "fire wide, self-cancel cheap" pattern
+- Extracted plan-mode judgment from approach-assessment into a dedicated `50-plan-mode.json` nudge (UserPromptSubmit, priority 50, always-evaluate via non_slash-only criteria); approach-assessment now focuses purely on approach selection (subagent/orchestration/just-do-it); plan-mode nudge owns "whether to plan at all" via model self-assessment with no keyword gate (complexity is not lexical)
 <!-- END AUTO-MANAGED -->
 
 <!-- AUTO-MANAGED: best-practices -->

--- a/nudges/UserPromptSubmit/10-approach-assessment.json
+++ b/nudges/UserPromptSubmit/10-approach-assessment.json
@@ -1,7 +1,7 @@
 {
   "id": "approach-assessment",
   "event": "UserPromptSubmit",
-  "description": "Self-assessing approach nudge. On a request that looks non-trivial (implement/build/refactor/migrate/multi-file), raises the question of which approach fits - plan, subagent, heavier orchestration, or just do it - and reminds that a spawned subagent needs context passed explicitly (parent-side advice, correctly homed on a parent-read event). High-recall keyword gate, so it leads with a condition and self-cancels false positives. Pure data, non-slash, ignorecase.",
+  "description": "Self-assessing approach nudge. On a request that looks non-trivial (implement/build/refactor/migrate/multi-file), raises the question of which approach fits - subagent, heavier orchestration, or just do it - and reminds that a spawned subagent needs context passed explicitly (parent-side advice, correctly homed on a parent-read event). The 'whether to plan at all' judgment is owned by the plan-mode nudge, so this no longer mentions plans. High-recall keyword gate, so it leads with a condition and self-cancels false positives. Pure data, non-slash, ignorecase.",
   "criteria": {
     "match": ["\\b(implement|build|refactor|migrate|redesign|rewrite|integrate|add .* (feature|support)|set up|across (the|all)|multiple)\\b"],
     "flags": ["ignorecase"],
@@ -10,7 +10,7 @@
   "action": {
     "type": "inject_context",
     "text": [
-      "If this is more than a quick change, choose the approach before starting: a reviewable plan for multi-file or architectural work, a subagent for exploration that would otherwise fill your context, heavier orchestration only when simpler steps fall short.",
+      "If this is more than a quick change, choose how to carry it out: a subagent for exploration that would otherwise fill your context, heavier orchestration only when simpler steps fall short.",
       "Otherwise just do it - match the effort to the task.",
       "A subagent cannot see this conversation, so pass it the context it needs."
     ]

--- a/nudges/UserPromptSubmit/40-ask-user-question.json
+++ b/nudges/UserPromptSubmit/40-ask-user-question.json
@@ -1,0 +1,19 @@
+{
+  "id": "ask-user-question",
+  "event": "UserPromptSubmit",
+  "description": "Self-cancelling nudge to route genuine user-owned decisions through the AskUserQuestion tool with concrete options, and to research first when context is too thin to frame those options. High-recall keyword gate on decision/fork language, so it leads with a condition; the 'pick a default and move on' counterweight doubles as the self-cancel for false positives and keeps it from pushing constant interruptions. Pure data, non-slash, ignorecase.",
+  "criteria": {
+    "match": ["\\b(which|should (i|we)|prefer|choose|choice|decide|decision|options?|recommend\\w*|better|versus|vs|trade-?offs?|pick)\\b"],
+    "flags": ["ignorecase"],
+    "non_slash": true
+  },
+  "action": {
+    "type": "inject_context",
+    "text": [
+      "If carrying out this request means making a decision that is genuinely the user's (an ambiguous fork, a real tradeoff, missing requirements): ask with the AskUserQuestion tool rather than guessing or burying the choice in prose - concrete options with their tradeoffs let the user react and think critically.",
+      "When you lack the context to frame those options well, research and explore first so the questions are specific and grounded, not generic.",
+      "For minor or reversible choices, pick a sensible default, note it, and proceed - only interrupt for decisions that genuinely need the user."
+    ]
+  },
+  "priority": 40
+}

--- a/nudges/UserPromptSubmit/50-plan-mode.json
+++ b/nudges/UserPromptSubmit/50-plan-mode.json
@@ -1,0 +1,16 @@
+{
+  "id": "plan-mode",
+  "event": "UserPromptSubmit",
+  "description": "Always-evaluate plan-mode wrapper. Complexity is not lexical (a one-line ask can be deep, a verbose ask can be trivial), so this cannot be keyword-gated - it injects an evaluation instruction on every real prompt and lets the model self-assess against full context, the way improve does for vagueness. Pure data with a non_slash-only criteria block: no match patterns means it always evaluates, but the criteria block still routes through the engine's default bypass so */#/empty and slash commands stay silent. Owns the 'whether to plan at all' judgment; approach-assessment owns 'which approach'.",
+  "criteria": {
+    "non_slash": true
+  },
+  "action": {
+    "type": "inject_context",
+    "text": [
+      "Before starting, judge whether this task is complex, multi-step, ambiguous, or architectural enough to benefit from a plan reviewed before any code is written - if so, enter plan mode first to align on the approach.",
+      "If it is straightforward or a single clear step, just proceed - do not plan trivial work."
+    ]
+  },
+  "priority": 50
+}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -212,7 +212,7 @@ def test_approach_assessment_fires_on_complexity_keyword():
         ),
         "UserPromptSubmit",
     )
-    assert "choose the approach before starting" in context
+    assert "choose how to carry it out" in context
 
 
 def test_approach_assessment_silent_on_trivial_prompt():
@@ -221,7 +221,46 @@ def test_approach_assessment_silent_on_trivial_prompt():
         run_engine("UserPromptSubmit", {"prompt": "fix typo in README"}),
         "UserPromptSubmit",
     )
-    assert "choose the approach before starting" not in context
+    assert "choose how to carry it out" not in context
+
+
+def test_ask_user_question_fires_on_decision_keyword():
+    """A prompt with a user-owned decision fork triggers the ask-user-question nudge"""
+    context = context_of(
+        run_engine(
+            "UserPromptSubmit", {"prompt": "which database should we use for this"}
+        ),
+        "UserPromptSubmit",
+    )
+    assert "AskUserQuestion" in context
+    assert "think critically" in context
+
+
+def test_ask_user_question_silent_on_plain_prompt():
+    """A prompt with no decision language has the improve wrapper but no ask guidance"""
+    context = context_of(
+        run_engine("UserPromptSubmit", {"prompt": "add a comment to utils.py"}),
+        "UserPromptSubmit",
+    )
+    assert "AskUserQuestion" not in context
+
+
+def test_plan_mode_evaluates_on_any_prompt():
+    """The plan-mode nudge always evaluates - it fires even with no complexity keyword"""
+    context = context_of(
+        run_engine("UserPromptSubmit", {"prompt": "fix typo in README"}),
+        "UserPromptSubmit",
+    )
+    assert "judge whether this task is complex" in context
+
+
+def test_plan_mode_silent_on_bypass():
+    """The plan-mode nudge respects the engine's default bypass (* prefix stays silent)"""
+    context = context_of(
+        run_engine("UserPromptSubmit", {"prompt": "* build a workflow"}),
+        "UserPromptSubmit",
+    )
+    assert "judge whether this task is complex" not in context
 
 
 def test_subagentstart_routing_fires():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,8 +39,8 @@ def test_plugin_configuration():
 
     config = json.loads(PLUGIN_JSON.read_text())
 
-    # Check version is 0.6.0
-    assert config["version"] == "0.6.0", f"Expected version 0.6.0, got {config['version']}"
+    # Check version is 0.6.1
+    assert config["version"] == "0.6.1", f"Expected version 0.6.1, got {config['version']}"
 
     # Check hooks field is NOT present (standard hooks/hooks.json is auto-discovered)
     assert "hooks" not in config, "The 'hooks' field should not be present (standard location is auto-discovered)"


### PR DESCRIPTION
## Summary

Two new `UserPromptSubmit` nudges plus an overlap trim, all pure-data rows (zero Python):

- **ask-user-question** (priority 40): keyword-gated on decision/fork language (which/should/prefer/choose/decide/options/recommend/better/vs/trade-offs/pick). Routes genuine user-owned decisions through the `AskUserQuestion` tool with concrete options so the user can think critically, grounds questions in research when context is thin, and defers to a sensible default for minor/reversible choices. Self-cancels false positives via the leading condition.
- **plan-mode** (priority 50): `non_slash`-only criteria with no `match` patterns, so it always evaluates. Injects an eval-then-branch instruction - judge whether the task is complex/multi-step/ambiguous/architectural enough to warrant a reviewed plan, enter plan mode if so, otherwise proceed. Complexity is not lexical, so it cannot be keyword-gated; the open gate is what lets it evaluate every task regardless of wording, while the engine's default bypass still keeps `*`/`#`/empty silent.
- **approach-assessment**: trimmed the plan line from its guidance text and description. It now owns "which approach" (subagent vs orchestration vs just do it); plan-mode owns "whether to plan at all". No overlap.

## Design notes

- Both new nudges target axes the existing set did not cover: an explicit user-owned fork (lexical signal, so gated) and task complexity (no lexical signal, so always-evaluate). The gating choice follows directly from whether the signal lives in the prompt text.
- No behavior-changing contradiction with the always-on `improve` nudge: `improve` measures clarity ("don't invoke the skill"), plan-mode measures complexity ("plan before building"). Entering plan mode satisfies both.

## Testing

- `python3 -m pytest tests/` - 104 passed.
- 2 plan-mode tests added: always-fires on a no-keyword prompt, and stays silent under `*` bypass.
- 2 approach-assessment assertions updated to the trimmed wording.

## Release

Additive, backward-compatible. Intended for the **v0.6.1** tag, cut on the merge commit per the existing release convention.