### PR TITLE
fix: skip harness-generated machine events in prompt nudges

### DIFF
--- a/scripts/engine.py
+++ b/scripts/engine.py
@@ -61,6 +61,18 @@ def _target_value(data, match_target):
     return value if isinstance(value, str) else ""
 
 
+# Harness-generated messages (task notifications, slash-command relays,
+# local-command output, system reminders) are not user prompts; running
+# prompt-targeted nudges on them burns tokens on every background event.
+_MACHINE_EVENT_PREFIXES = (
+    "<task-notification>",
+    "<command-message>",
+    "<local-command-stdout>",
+    "<local-command-caveat>",
+    "<system-reminder>",
+)
+
+
 def _bypassed(target_value, match_target, bypass):
     """Default policy: suppress prompt-targeted rules on */#/empty input.
 
@@ -70,7 +82,12 @@ def _bypassed(target_value, match_target, bypass):
     if bypass == "none" or match_target != "prompt":
         return False
     stripped = target_value.lstrip()
-    return not stripped or stripped.startswith("*") or stripped.startswith("#")
+    return (
+        not stripped
+        or stripped.startswith("*")
+        or stripped.startswith("#")
+        or stripped.startswith(_MACHINE_EVENT_PREFIXES)
+    )
 
 
 def _passes_criteria(data, criteria):

--- a/scripts/nudge_builtins.py
+++ b/scripts/nudge_builtins.py
@@ -22,6 +22,14 @@ from pathlib import Path
 
 # --- improve: prompt-clarity evaluation wrapper -----------------------------
 
+_MACHINE_EVENT_PREFIXES = (
+    "<task-notification>",
+    "<command-message>",
+    "<local-command-stdout>",
+    "<local-command-caveat>",
+    "<system-reminder>",
+)
+
 _EVALUATION_WRAPPER = """PROMPT EVALUATION
 
 Original user request: "{prompt}"
@@ -56,6 +64,11 @@ def improve(data):
         return prompt[1:].strip()
     if prompt.startswith("/") or prompt.startswith("#"):
         return prompt
+    # Harness-generated messages (task notifications, command relays,
+    # system reminders) are not user prompts — wrapping them burns
+    # ~200 tokens per background event with zero value.
+    if prompt.lstrip().startswith(_MACHINE_EVENT_PREFIXES):
+        return ""
 
     # Escape backslashes first, then double-quotes, so the prompt embeds
     # safely inside the wrapper's quoted "Original user request" line.


### PR DESCRIPTION
Claude Code delivers harness-generated messages through `UserPromptSubmit` too: `<task-notification>` (background task completions), `<command-message>` relays, `<local-command-stdout>`/`<local-command-caveat>`, and `<system-reminder>`. These aren't user prompts — running the PROMPT EVALUATION nudge on them adds ~200 tokens per background event with zero value, and on busy multi-agent sessions they arrive constantly.

Adds the machine-event prefixes to both bypass layers:
- the evaluation handler (owns its own `*`/`/`/`#` bypass) — returns `""` so nothing is emitted
- `_bypassed()` in the engine, so prompt-targeted criteria rules skip them too (rules with `bypass: "none"` keep firing, unchanged)

Probed both directions: machine event → exit 0, zero output; genuine prompt → wraps as before.

(Running in production via a nix `applyPatches` overlay — happy to adjust shape/naming.)